### PR TITLE
Modify the scraper scripts and README documentation to make them a li…

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,10 +24,19 @@
 ## Usage
 
 1. Navigate to the prompt-scrape directory.
-2. Create your own file with input prompts. Any file format that can be read into a list of dictionaries works, `.JSONL` works the best
-3. Set the OpenAI API keys in your environment variables. You can also modify the openai_api_keys parameter in `Scraper()` to pass the keys as a list.
-4. Run `python scrape.py`
-5. The script will generate output JSONL files containing the prompt and response pairs, along with the model settings and source. The output files will be saved in the specified output path. Note that the output files will be appended if the path already exists.
+2. Create your own file with input prompts. Here is an example of an input file that will work out of the box with the scraper.py without modification:
+
+```
+{"prompt": "Can you write me a poem about kenneth fearing, aphrodite and jubal fearing in the style of KENNETH FEARING?", "source": "OIG - unified_poetry_instructions.jsonl"}
+{"prompt": "Can you write me a poem about wallace stevens and alfred a. knopf?", "source": "OIG - unified_poetry_instructions.jsonl"}
+{"prompt": "Can you write me a poem about time?", "source": "OIG - unified_poetry_instructions.jsonl"}
+```
+
+Other file formats will require either conversion to this format or modifications to scraper.py to accomodate your own custom format.
+
+3. Run `python scrape.py -k <OPENAI_API_KEY> /path/to/your/input_file.jsonl /path/to/your/output_file.jsonl`
+4. You can also set your OpenAI API keys to OPENAI_API_KEY environment variable.
+5. The script will generate output a JSON file containing the prompt and response pairs, along with the model settings and source. Note that the output files will be appended if the path already exists.
 6. You can modify the num_workers and shard_size parameters in `scrape()` to change the number of workers and the number of prompts processed per worker, respectively.
 
 Note: You will need a ChatGPT API key(s) to use this tool. You can obtain a key from the OpenAI website.

--- a/README.md
+++ b/README.md
@@ -23,6 +23,9 @@
 
 ## Usage
 
+This is an example of how you'd use the scraper on a jsonl file from the
+OIG project for instance - https://huggingface.co/datasets/laion/OIG/tree/main
+
 1. Navigate to the prompt-scrape directory.
 2. Create your own file with input prompts. Here is an example of an input file that will work out of the box with the scraper.py without modification:
 
@@ -31,8 +34,14 @@
 {"prompt": "Can you write me a poem about wallace stevens and alfred a. knopf?", "source": "OIG - unified_poetry_instructions.jsonl"}
 {"prompt": "Can you write me a poem about time?", "source": "OIG - unified_poetry_instructions.jsonl"}
 ```
-
 Other file formats will require either conversion to this format or modifications to scraper.py to accomodate your own custom format.
+
+  * To create such a file from an OIG jsonl file you can run:
+  `python convert_oig_to_scraper_input.py /path/to/OIG/file.jsonl /path/to/output_file.jsonl`
+
+  * If you are running the scraper on an OIG file you should first map the data with atlas to see if the data is of sufficient quality like this:
+  `python atlas_mapper.py /path/to/output_file.jsonl`
+  where the output file here is what was created in the previous step.
 
 3. Run `python scrape.py -k <OPENAI_API_KEY> /path/to/your/input_file.jsonl /path/to/your/output_file.jsonl`
 4. You can also set your OpenAI API keys to OPENAI_API_KEY environment variable.

--- a/prompt-scrape/atlas_mapper.py
+++ b/prompt-scrape/atlas_mapper.py
@@ -1,0 +1,25 @@
+import argparse
+import jsonlines
+from nomic import atlas
+
+# create an ArgumentParser object and define the command line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("input_file", help="path to the input json file")
+args = parser.parse_args()
+
+# load the data from the input file using jsonlines
+data = []
+with jsonlines.open(args.input_file, "r") as input_file:
+    for obj in input_file:
+        if 'source' not in obj:
+            obj['source'] = args.input_file
+        data.append(obj)
+
+print(f"processing {len(data)} items")
+
+# index the prompt field using atlas.map_text()
+project = atlas.map_text(data=data,
+                         indexed_field="prompt",
+                         name=args.input_file,
+                         colorable_fields=["source"]
+                        )

--- a/prompt-scrape/conversation.py
+++ b/prompt-scrape/conversation.py
@@ -1,3 +1,4 @@
+import argparse
 import concurrent
 import concurrent.futures
 import os
@@ -28,7 +29,8 @@ class Conversation:
 
         Args:
             self: An instance of the class that this method belongs to.
-            all_prompts (List[str]): A list of prompts to generate responses to.
+            all_prompts (List[dict]): A list of prompts as dictionary objects to generate responses to. Each dictionary object should
+            contain the 'prompt' key with a string value representing the prompt.
             i (int): An integer representing the starting index of the prompts to use in the all_prompts list.
             output_path (str, optional): The path to the file to write the generated responses to. Defaults to an empty string.
             source (str, optional): A string representing the source of the prompts. Defaults to an empty string.
@@ -38,7 +40,7 @@ class Conversation:
             Any exceptions thrown by the OpenAIChat model.
 
         """
-        prompts = all_prompts[i : i + shard_size]
+        prompts = [d['prompt'] for d in all_prompts[i : i + shard_size]]
         model = OpenAIChat(
             model_name="gpt-3.5-turbo",
             openai_api_key=self.openai_api_keys[random.randint(0, len(self.openai_api_keys) - 1)],
@@ -63,7 +65,7 @@ class Conversation:
                     writer.write(json_data)
                 except:
                     logger.warning("something went wrong! next")
-                    with jsonlines.open(f"{output_path}/fails.jsonl", mode="a") as writer:
+                    with jsonlines.open(f"{output_path}_fails.jsonl", mode="a") as writer:
                         writer.write(prompt)
 
     def conversation_collector(self, 
@@ -101,3 +103,30 @@ class Conversation:
                     logger.exception(f"Error processing prompt: {e}")
 
                 progress.update(1)
+
+if __name__ == "__main__":
+    # Parse command line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_file", help="Input file name")
+    parser.add_argument("output_file", help="Output file name")
+    parser.add_argument("-k", "--openai_api_key", help="OpenAI API key")
+    args = parser.parse_args()
+
+    # Get the OpenAI API key
+    openai_api_key = args.openai_api_key or os.environ.get("OPENAI_API_KEY")
+
+    # Create a Conversation instance
+    conversation = Conversation(openai_api_keys=[openai_api_key])
+
+    # Read the input prompts
+    all_data = []
+    with jsonlines.open(args.input_file, mode="r") as reader:
+        for datum in reader:
+            prompt = datum['prompt']
+            all_data.append({"prompt": prompt})
+
+    # Scrape the prompts
+    conversation.conversation_collector(
+        all_prompts=all_data,
+        output_path=args.output_file
+    )

--- a/prompt-scrape/convert_oig_to_scraper_input.py
+++ b/prompt-scrape/convert_oig_to_scraper_input.py
@@ -1,0 +1,33 @@
+import argparse
+import jsonlines
+
+# create an ArgumentParser object and define the command line arguments
+parser = argparse.ArgumentParser()
+parser.add_argument("input_file", help="path to the input JSON file")
+parser.add_argument("output_file", help="path to the output JSONLINES file")
+args = parser.parse_args()
+
+# open the input file and read the data
+with open(args.input_file, "r") as input_file:
+    input_data = jsonlines.Reader(input_file)
+
+    # open the output file and write the output data as a JSONLINES file
+    with open(args.output_file, "w") as output_file:
+        output_data = jsonlines.Writer(output_file)
+
+        # process each JSON object in the input data
+        for json_obj in input_data:
+            # extract the prompt and source fields
+            prompt = json_obj["text"]
+            source = json_obj["metadata"]["source"]
+
+            # remove the "<human>:" and "<bot>:" tags and everything that comes after them
+            prompt = prompt.split("<human>: ")[-1]
+            prompt = prompt.split("<bot>:")[0]
+
+            # strip leading and trailing whitespace from the prompt
+            prompt = prompt.strip()
+
+            # create a new object with the processed data and add it to the output file
+            output_obj = {"prompt": prompt, "source": source}
+            output_data.write(output_obj)

--- a/prompt-scrape/scrape.py
+++ b/prompt-scrape/scrape.py
@@ -1,3 +1,4 @@
+import argparse
 import concurrent
 import concurrent.futures
 import os
@@ -29,7 +30,7 @@ class Scraper:
 
         Args:
             all_prompts (List[dict]): A list of prompts as dictionary objects to generate responses to. Each dictionary object should
-            contain the 'text' key with a string value representing the prompt.
+            contain the 'prompt' key with a string value representing the prompt.
             i (int): An integer representing the starting index of the prompts to use in the all_prompts list.
             shard_size (int): An integer representing the number of prompts to generate responses for in each iteration.
             model_settings (dict, optional): A dictionary of settings to pass to the OpenAIChat model. Defaults to {"max_tokens": -1}.
@@ -40,7 +41,7 @@ class Scraper:
             Any exceptions thrown by the OpenAIChat model or jsonlines module.
 
         """
-        prompts = all_prompts[i : i + shard_size]
+        prompts = [d['prompt'] for d in all_prompts[i : i + shard_size]]
         model = OpenAIChat(
             model_name="gpt-3.5-turbo",
             openai_api_key=self.openai_api_keys[random.randint(0, len(self.openai_api_keys) - 1)],
@@ -48,13 +49,13 @@ class Scraper:
         )
         for prompt in tqdm(prompts):
             output = model(prompt)
-            with jsonlines.open(os.path.join(output_path, "output.jsonl"), mode="a") as writer:
+            with jsonlines.open(output_path, mode="a") as writer:
                 try:
                     json_data = {"prompt": prompt, "response": output, "model_settings": model_settings, "source": source}
                     writer.write(json_data)
                 except (KeyboardInterrupt, ValueError, IndexError):
                     logger.warning("Something went wrong with this prompt! Skipping to next one")
-                    with jsonlines.open(os.path.join(output_path, "fails.jsonl"), mode="a") as writer:
+                    with jsonlines.open(output_path + "_fails.jsonl", mode="a") as writer:
                         writer.write(prompt)
 
     def collector(self, 
@@ -77,3 +78,30 @@ class Scraper:
                     logger.exception(f"Error processing prompt: {e}")
 
                 progress.update(1)
+
+if __name__ == "__main__":
+    # Parse command line arguments
+    parser = argparse.ArgumentParser()
+    parser.add_argument("input_file", help="Input file name")
+    parser.add_argument("output_file", help="Output file name")
+    parser.add_argument("-k", "--openai_api_key", help="OpenAI API key")
+    args = parser.parse_args()
+
+    # Get the OpenAI API key
+    openai_api_key = args.openai_api_key or os.environ.get("OPENAI_API_KEY")
+
+    # Create a Scraper instance
+    scraper = Scraper(openai_api_keys=[openai_api_key])
+
+    # Read the input prompts
+    all_data = []
+    with jsonlines.open(args.input_file, mode="r") as reader:
+        for datum in reader:
+            prompt = datum['prompt']
+            all_data.append({"prompt": prompt})
+
+    # Scrape the prompts
+    scraper.collector(
+        all_prompts=all_data,
+        output_path=args.output_file
+    )


### PR DESCRIPTION
…ttle

more turn key. This puts the onus on the user to turn their input file format into the format that the scraper expects rather than making them modify the scraper itself. Also, this gives helpful command line arguments to the scraper and makes it so the scraper will scrape one jsonl file at a time.